### PR TITLE
Added more granularity to CSS mixins

### DIFF
--- a/px-table-row.html
+++ b/px-table-row.html
@@ -89,9 +89,7 @@ Custom property | Description | Default
     :host .table-row__media{
       @apply(--px-table-row-media);
     }
-		:host .table-row__media--icon{
-			@apply(--px-table-row-media--icon)
-		}
+
 		:host .table-row__media--left{
 			@apply(--px-table-row-media--left)
 		}

--- a/px-table-row.html
+++ b/px-table-row.html
@@ -89,6 +89,15 @@ Custom property | Description | Default
     :host .table-row__media{
       @apply(--px-table-row-media);
     }
+		:host .table-row__media--icon{
+			@apply(--px-table-row-media--icon)
+		}
+		:host .table-row__media--left{
+			@apply(--px-table-row-media--left)
+		}
+		:host .table-row__media--right{
+			@apply(--px-table-row-media--right)
+		}
 
     :host .table-row__media img{
       @apply(--px-table-row-media-img);


### PR DESCRIPTION
table-row__label--left and table-row__label--right are customizable on their own right, but media gets a blanket mixin. This edit adds in individual mixins for table-row__media--left, table-row__media--right, and table-row__media--icon

[See picture](http://imgur.com/f4NQgWx)
